### PR TITLE
test: use yaml scalar chomping indicator

### DIFF
--- a/plugins/sogo-rule-exclusions-before.conf
+++ b/plugins/sogo-rule-exclusions-before.conf
@@ -50,6 +50,7 @@ SecRule REQUEST_FILENAME "@beginsWith /SOGo/" \
     nolog,\
     ctl:ruleRemoveTargetById=920272;REQUEST_HEADERS:cookie,\
     ctl:ruleRemoveTargetById=920273;REQUEST_HEADERS:cookie,\
+    ctl:ruleRemoveTargetById=921140;REQUEST_HEADERS:cookie,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:XSRF-TOKEN,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:XSRF-TOKEN,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:0xHIGHFLYxSOGo,\

--- a/plugins/sogo-rule-exclusions-before.conf
+++ b/plugins/sogo-rule-exclusions-before.conf
@@ -48,9 +48,9 @@ SecRule REQUEST_FILENAME "@beginsWith /SOGo/" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=920272;REQUEST_HEADERS:cookie,\
-    ctl:ruleRemoveTargetById=920273;REQUEST_HEADERS:cookie,\
-    ctl:ruleRemoveTargetById=921140;REQUEST_HEADERS:cookie,\
+    ctl:ruleRemoveTargetById=920272;REQUEST_HEADERS:Cookie,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_HEADERS:Cookie,\
+    ctl:ruleRemoveTargetById=921140;REQUEST_HEADERS:Cookie,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:XSRF-TOKEN,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:XSRF-TOKEN,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:0xHIGHFLYxSOGo,\

--- a/tests/regression/sogo-rule-exclusions-plugin/9520100.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520100.yaml
@@ -6,7 +6,7 @@ meta:
   name: 9520100.yaml
 tests:
   - test_title: 9520100-1
-    desc: Disable 920272 and 920273 for cookie header
+    desc: Disable 920272, 920273, and 921140 for cookie header
     stages:
       - stage:
           input:
@@ -15,16 +15,16 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              cookie: 0xHIGHFLYxSOGo=basic%20NmFxMHZ3UTNMaG5QSmh0ZitFRHNtTVl1SWwxZU5xMz%
+              Cookie: 0xHIGHFLYxSOGo=basic%20NmFxMHZ3UTNMaG5QSmh0ZitFRHNtTVl1SWwxZU5xMz%
             port: 80
-            method: POST
-            uri: /SOGo/
+            method: GET
+            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
             version: HTTP/1.1
           output:
-            no_log_contains: |
-              id "920273"|id "920272"
+            no_log_contains: |-
+              id "920272"|id "920273"|id "921140"
   - test_title: 9520100-2
-    desc: Disable 942450 for XSRF-TOKEN cookie
+    desc: Disable 942450 for XSRF-TOKEN and 0xHIGHFLYxSOGo cookie
     stages:
       - stage:
           input:
@@ -33,15 +33,15 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              cookie: XSRF-TOKEN=0x080069f28b16140b7e860c363fb8e777e796a0581a1d
+              Cookie: XSRF-TOKEN=0x080069f28b16140b7e860c363fb8e777e796a0581a1d; 0xHIGHFLYxSOGo=0x0800
             port: 80
-            method: POST
-            uri: /SOGo/
+            method: GET
+            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
             version: HTTP/1.1
           output:
             no_log_contains: id "942450"
   - test_title: 9520100-3
-    desc: Disable 932236 for XSRF-TOKEN cookie
+    desc: Disable 932236 for XSRF-TOKEN and 0xHIGHFLYxSOGo cookie
     stages:
       - stage:
           input:
@@ -50,44 +50,10 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              cookie: XSRF-TOKEN=ls69f28b16140b7e860c363fb8e777e796a0581a1d
+              Cookie: XSRF-TOKEN=ls69f28b16140b7e860c363fb8e777e796a0581a1d; 0xHIGHFLYxSOGo=lsnbjdaf
             port: 80
-            method: POST
-            uri: /SOGo/
-            version: HTTP/1.1
-          output:
-            no_log_contains: id "932236"
-  - test_title: 9520100-4
-    desc: Disable 942450 for 0xHIGHFLYxSOGo cookie
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: SOGo rule exclusions plugin
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              cookie: 0xHIGHFLYxSOGo=0x0800
-            port: 80
-            method: POST
-            uri: /SOGo/
-            version: HTTP/1.1
-          output:
-            no_log_contains: id "942450"
-  - test_title: 9520100-5
-    desc: Disable 932236 for 0xHIGHFLYxSOGo cookie
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: SOGo rule exclusions plugin
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              cookie: 0xHIGHFLYxSOGo=lsnbjdaf
-            port: 80
-            method: POST
-            uri: /SOGo/
+            method: GET
+            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
             version: HTTP/1.1
           output:
             no_log_contains: id "932236"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520100.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520100.yaml
@@ -18,7 +18,7 @@ tests:
               Cookie: 0xHIGHFLYxSOGo=basic%20NmFxMHZ3UTNMaG5QSmh0ZitFRHNtTVl1SWwxZU5xMz%
             port: 80
             method: GET
-            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
+            uri: /SOGo/so/postmaster@example.com/Mail/view
             version: HTTP/1.1
           output:
             no_log_contains: |-
@@ -36,7 +36,7 @@ tests:
               Cookie: XSRF-TOKEN=0x080069f28b16140b7e860c363fb8e777e796a0581a1d; 0xHIGHFLYxSOGo=0x0800
             port: 80
             method: GET
-            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
+            uri: /SOGo/so/postmaster@example.com/Mail/view
             version: HTTP/1.1
           output:
             no_log_contains: id "942450"
@@ -53,7 +53,7 @@ tests:
               Cookie: XSRF-TOKEN=ls69f28b16140b7e860c363fb8e777e796a0581a1d; 0xHIGHFLYxSOGo=lsnbjdaf
             port: 80
             method: GET
-            uri: /SOGo/so/postmaster@example.com/Mail/view#!/Mail/0/INBOX
+            uri: /SOGo/so/postmaster@example.com/Mail/view
             version: HTTP/1.1
           output:
             no_log_contains: id "932236"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520101.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520101.yaml
@@ -19,9 +19,9 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/connect
-            data: |
+            data: |-
               { "userName": "postmaster@example.com", "password": "<script>", "domain": null, "rememberLogin": 0 }
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"|id "941110"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520102.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520102.yaml
@@ -16,7 +16,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/example.com
             version: HTTP/1.1
           output:
@@ -32,7 +32,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/so/example.com
             version: HTTP/1.1
           output:
@@ -48,7 +48,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/dav/example.com
             version: HTTP/1.1
           output:
@@ -64,7 +64,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/example.inc
             version: HTTP/1.1
           output:
@@ -80,7 +80,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/so/example.inc
             version: HTTP/1.1
           output:
@@ -96,7 +96,7 @@ tests:
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
-            method: POST
+            method: GET
             uri: /SOGo/dav/example.inc
             version: HTTP/1.1
           output:

--- a/tests/regression/sogo-rule-exclusions-plugin/9520104.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520104.yaml
@@ -19,11 +19,11 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/so/user@example.com/Mail/4/folderDrafts/newDraft-4/send
-            data: |
+            data: |-
               {"to":["postmaster  <postmaster@example.com>"],"cc":[],"bcc":[],"isHTML":1,"text":"<p>&lt;script&gt;</p>","from":"postmaster <postmaster@example.com>","locale":"en","subject":"<script>"}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942131"|id "942432"|id "941110"
   - test_title: 9520104-2
     desc: Saving an draft email
@@ -39,9 +39,9 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/so/user@example.com/Mail/4/folderDrafts/newDraft-4/save
-            data: |
+            data: |-
               {"to":["postmaster  <postmaster@example.com>"],"cc":[],"bcc":[],"isHTML":1,"text":"<p>&lt;script&gt;</p>","from":"postmaster <postmaster@example.com>","locale":"en","subject":"<script>"}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942131"|id "942432"|id "941110"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520105.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520105.yaml
@@ -19,9 +19,9 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/so/passwordRecoveryEnabled
-            data: |
+            data: |-
               {"userName":"postmaster@example.com","domain":null}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520110.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520110.yaml
@@ -19,9 +19,9 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/so/changePassword
-            data: |
+            data: |-
               { "userName":null,"newPassword":"<script>","oldPassword":"<script>" }
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"|id "941110"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520111.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520111.yaml
@@ -46,5 +46,5 @@ tests:
               "PreventInvitationsWhitelist":{},"EventsSortingState":["start","1"]},"ShowCompletedTasks":"0","General":{"PrivateSalt":"6c92b8b8d902cee3228ecacd0c33ad7433b451bf"}},"inboxSyncToken":"7-11"}
             version: HTTP/1.1
             output:
-              no_log_contains: |
+              no_log_contains: |-
                 id "920272"|id "920273"|id "921180"|id "931130"|id "932236"|id "942131"|id "942432"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520120.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520120.yaml
@@ -25,5 +25,5 @@ tests:
               "addresses":[{"type":"","postoffice":"","street":"","street2":"","locality":"","region":"","country":"","postalcode":""}],"birthday":"" }
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"|id "931130"|id "942432"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520121.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520121.yaml
@@ -24,5 +24,5 @@ tests:
               "publicCardDavURL":"","cardDavURL":"https://sogo.example.com/SOGo/dav/postmaster@example.com/Contacts/1BE-65E5E580-B-1B22B300/","synchronize":1 }
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273|"id "931130"|id "932236"|id "942432"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520130.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520130.yaml
@@ -27,7 +27,7 @@ tests:
               "location":"test","startDate":"2024-03-05","startTime":"02:30","endDate":"","endTime":"","dueTime":"02:30","completedDate":"2024-03-05"}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "931130"|id "932236"|id "942432"
   - test_title: 9520130-2
     desc: Modifying an existing Calendar task
@@ -52,7 +52,7 @@ tests:
               "$hasAlarm":false,"destinationCalendar":"personal","selected":false,"startTime":"02:30","endDate":"","endTime":"","dueTime":"02:30","completedDate":"2024-03-05"}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "931130"|id "932236"|id "942432"
   - test_title: 9520130-3
     desc: Modifying an existing Calendar event
@@ -78,7 +78,7 @@ tests:
               "dueDate":"","dueTime":"","completedDate":""}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "931130"|id "932236"|id "942432"
   - test_title: 9520130-4
     desc: Creating an calendar event
@@ -102,5 +102,5 @@ tests:
               "dueDate":"","dueTime":"","completedDate":""}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "931130"|id "932236"|id "942432"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520132.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520132.yaml
@@ -29,5 +29,5 @@ tests:
               "acls":{"objectEraser":1,"objectCreator":1},"isOwned":true,"isSubscription":false}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"|id "931130"|id "942432"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520133.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520133.yaml
@@ -19,9 +19,9 @@ tests:
             port: 80
             method: POST
             uri: /SOGo/so/user@example.com/Calendar/addWebCalendar
-            data: |
+            data: |-
               {"url":"https://example.com/"}
             version: HTTP/1.1
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920272"|id "920273"|id "931130"


### PR DESCRIPTION
Use the YAML scalar chomping indicator to avoid adding a newline in payloads or checking for a newline when checking for rule IDs in tests. This can cause some tests to incorrectly fail or pass. Some other minor improvements were made in tests.