### PR TITLE
fix: false positive when creating new calendar group and syncing on apache

### DIFF
--- a/plugins/sogo-rule-exclusions-before.conf
+++ b/plugins/sogo-rule-exclusions-before.conf
@@ -329,14 +329,20 @@ SecRule REQUEST_FILENAME "@beginsWith /SOGo/dav" \
     nolog,\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=920273;XML,\
+    ctl:ruleRemoveTargetById=942421;XML,\
+    ctl:ruleRemoveTargetById=942430;XML,\
+    ctl:ruleRemoveTargetById=942431;XML,\
+    ctl:ruleRemoveTargetById=942432;XML,\
+    ctl:ruleRemoveTargetById=942440;XML,\
     ctl:ruleRemoveTargetById=920273;XML:/*,\
+    ctl:ruleRemoveTargetById=942421;XML:/*,\
     ctl:ruleRemoveTargetById=942430;XML:/*,\
     ctl:ruleRemoveTargetById=942431;XML:/*,\
-    ctl:ruleRemoveTargetById=942421;XML:/*,\
     ctl:ruleRemoveTargetById=942432;XML:/*,\
     ctl:ruleRemoveTargetById=942440;XML:/*,\
     ver:'sogo-rule-exclusions-plugin/1.0.3',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE PROPFIND REPORT MKCOL'"
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE PROPFIND REPORT MKCOL MKCALENDAR'"
 
 # When modifying/creating contacts via mobile DAV client
 SecRule REQUEST_FILENAME "@rx ^/SOGo/dav/[^/]+/Contacts/[^/]+/[^/]+\.vcf$" \

--- a/tests/regression/sogo-rule-exclusions-plugin/9520140.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520140.yaml
@@ -38,22 +38,6 @@ tests:
           output:
             no_log_contains: id "911000"
   - test_title: 9520140-3
-    desc: Allow PROPFIND request method for Caldav/Cardav
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: SOGo rule exclusions plugin
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: PROPFIND
-            uri: /SOGo/dav/stuff
-            version: HTTP/1.1
-          output:
-            no_log_contains: id "911000"
-  - test_title: 9520140-4
     desc: Allow REPORT request method for Caldav/Cardav
     stages:
       - stage:
@@ -69,8 +53,8 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "911000"
-  - test_title: 9520140-5
-    desc: Allow MKCOL request method for Caldav/Cardav
+  - test_title: 9520140-4
+    desc: Creating a new contact group
     stages:
       - stage:
           input:
@@ -79,9 +63,235 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml; charset=utf-8
             port: 80
             method: MKCOL
-            uri: /SOGo/dav/stuff
+            uri: /SOGo/dav/user@example.com/Contacts/e2f60a2d-d8e4-48ce-9478-16be8b0b5790/
+            data: |-
+              <?xml version='1.0' encoding='UTF-8' ?>
+                <mkcol xmlns="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+                  <set>
+                    <prop>
+                      <resourcetype>
+                      <collection />
+                      <CARD:addressbook />
+                      </resourcetype>
+                      <displayname>test</displayname>
+                      <CARD:addressbook-description>
+                      </CARD:addressbook-description>
+                    </prop>
+                  </set>
+                </mkcol>
             version: HTTP/1.1
           output:
-            no_log_contains: id "911000"
+            no_log_contains: |-
+              id "911100"|id "920272"|id "920273"|id "942421"|id "942430"|id "942431"|id "942432"|id "942440"
+  - test_title: 9520140-5
+    desc: Getting Calendar information stored on the servers
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: SOGo rule exclusions plugin
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml; charset=utf-8
+            port: 80
+            method: PROPFIND
+            uri: /SOGo/dav/user@example.com/Calendar/personal/
+            data: |-
+              <?xml version='1.0' encoding='UTF-8' ?>
+                <propfind xmlns="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+                  <prop>
+                    <CAL:max-resource-size />
+                    <n0:getctag xmlns:n0="http://calendarserver.org/ns/" />
+                    <sync-token />
+                  </prop>
+                </propfind>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "911100"|id "920272"|id "920273"|id "942421"|id "942430"|id "942431"|id "942432"|id "942440"
+  - test_title: 9520140-6
+    desc: Getting Contact information stored on the servers
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: SOGo rule exclusions plugin
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml; charset=utf-8
+            port: 80
+            method: PROPFIND
+            uri: /SOGo/dav/user@example.com/Contacts/users/
+            data: |-
+              <?xml version='1.0' encoding='UTF-8' ?>
+                <propfind xmlns="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+                  <prop>
+                    <CARD:max-resource-size />
+                    <CARD:supported-address-data /><supported-report-set />
+                    <n0:getctag xmlns:n0="http://calendarserver.org/ns/" />
+                    <sync-token />
+                  </prop>
+                </propfind>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "911100"|id "920272"|id "920273"|id "942421"|id "942430"|id "942431"|id "942432"|id "942440"
+  - test_title: 9520140-7
+    desc: Creating a new Calendar group
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: SOGo rule exclusions plugin
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml; charset=utf-8
+            port: 80
+            method: MKCALENDAR
+            uri: /SOGo/dav/user@example.com/Calendar/4988f589-48a3-4263-a7a2-dcc5adce5606/
+            data: |-
+              <?xml version='1.0' encoding='UTF-8' ?>
+                <CAL:mkcalendar xmlns="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+                  <set>
+                    <prop>
+                      <resourcetype>
+                        <collection />
+                        <CAL:calendar />
+                      </resourcetype>
+                      <displayname>test</displayname>
+                      <CAL:calendar-description></CAL:calendar-description>
+                      <n0:calendar-color xmlns:n0="http://apple.com/ns/ical/">#BDB76BFF</n0:calendar-color>
+                      <CAL:calendar-timezone-id>Australia/Melbourne</CAL:calendar-timezone-id>
+                      <CAL:calendar-timezone>BEGIN:VCALENDAR
+                        PRODID:+//IDN bitfire.at//ical4android
+                        VERSION:2.0
+                        BEGIN:VTIMEZONE
+                        TZID:Australia/Melbourne
+                        LAST-MODIFIED:20240422T053450Z
+                        TZURL:https://www.tzurl.org/zoneinfo/Australia/Melbourne
+                        X-LIC-LOCATION:Australia/Melbourne
+                        X-PROLEPTIC-TZNAME:LMT
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+093952
+                        TZOFFSETTO:+1000
+                        DTSTART:18950201T000000
+                        END:STANDARD
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:19170101T020000
+                        RDATE:19420101T020000
+                        RDATE:19420927T020000
+                        RDATE:19431003T020000
+                        RDATE:20000827T020000
+                        END:DAYLIGHT
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19170325T030000
+                        RDATE:19720227T030000
+                        RDATE:20060402T030000
+                        RDATE:20070325T030000
+                        END:STANDARD
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19420329T030000
+                        RRULE:FREQ=YEARLY;UNTIL=19440325T160000Z;BYMONTH=3;BYDAY=-1SU
+                        END:STANDARD
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1000
+                        DTSTART:19710101T000000
+                        END:STANDARD
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:19711031T020000
+                        RRULE:FREQ=YEARLY;UNTIL=19851026T160000Z;BYMONTH=10;BYDAY=-1SU
+                        END:DAYLIGHT
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19730304T030000
+                        RRULE:FREQ=YEARLY;UNTIL=19850302T160000Z;BYMONTH=3;BYDAY=1SU
+                        END:STANDARD
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19860316T030000
+                        RRULE:FREQ=YEARLY;UNTIL=19900317T160000Z;BYMONTH=3;BYDAY=3SU
+                        END:STANDARD
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:19861019T020000
+                        RRULE:FREQ=YEARLY;UNTIL=19871017T160000Z;BYMONTH=10;BYDAY=3SU
+                        END:DAYLIGHT
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:19881030T020000
+                        RRULE:FREQ=YEARLY;UNTIL=19991030T160000Z;BYMONTH=10;BYDAY=-1SU
+                        END:DAYLIGHT
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19910303T030000
+                        RRULE:FREQ=YEARLY;UNTIL=19940305T160000Z;BYMONTH=3;BYDAY=1SU
+                        END:STANDARD
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:19950326T030000
+                        RRULE:FREQ=YEARLY;UNTIL=20050326T160000Z;BYMONTH=3;BYDAY=-1SU
+                        END:STANDARD
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:20011028T020000
+                        RRULE:FREQ=YEARLY;UNTIL=20071027T160000Z;BYMONTH=10;BYDAY=-1SU
+                        END:DAYLIGHT
+                        BEGIN:STANDARD
+                        TZNAME:AEST
+                        TZOFFSETFROM:+1100
+                        TZOFFSETTO:+1000
+                        DTSTART:20080406T030000
+                        RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU
+                        END:STANDARD
+                        BEGIN:DAYLIGHT
+                        TZNAME:AEDT
+                        TZOFFSETFROM:+1000
+                        TZOFFSETTO:+1100
+                        DTSTART:20081005T020000
+                        RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU
+                        END:DAYLIGHT
+                        END:VTIMEZONE
+                        END:VCALENDAR
+                      </CAL:calendar-timezone>
+                    </prop>
+                  </set>
+                </CAL:mkcalendar>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "911100"|id "920272"|id "920273"|id "942421"|id "942430"|id "942431"|id "942432"|id "942440"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520141.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520141.yaml
@@ -6,7 +6,7 @@ meta:
   name: 9520141.yaml
 tests:
   - test_title: 9520141-1
-    desc: Allow text/vcard content type for cardav
+    desc: Creating a contact via an DAV client
     stages:
       - stage:
           input:
@@ -15,10 +15,19 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: text/vcard
+              Content-Type: text/vcard;charset=utf-8
             port: 80
-            method: GET
-            uri: /SOGo/dav/username/Contacts/work/johndoe.vcf
+            method: PUT
+            uri: /SOGo/dav/user@example.com/Contacts/users/7b3b2e62-e426-49e1-afd7-950da0d10997.vcf
+            data: |-
+              BEGIN:VCARD                                                                                                                                                                                                                                                                   VERSION:3.0
+              PRODID:+//IDN bitfire.at//DAVx5/4.4.8-ose ez-vcard/0.12.1
+              UID:7b3b2e62-e426-49e1-afd7-950da0d10997
+              FN:Test
+              N:;Test;;;
+              REV:2025-03-19T04:33:28Z
+              END:VCARD
             version: HTTP/1.1
           output:
-            no_log_contains: id "920420"
+            no_log_contains: |-
+              id "911100"|id "920420"

--- a/tests/regression/sogo-rule-exclusions-plugin/9520142.yaml
+++ b/tests/regression/sogo-rule-exclusions-plugin/9520142.yaml
@@ -6,7 +6,7 @@ meta:
   name: 9520142.yaml
 tests:
   - test_title: 9520142-1
-    desc: Allow text/calendar content type for caldav
+    desc: Creating an Calendar via an DAV client
     stages:
       - stage:
           input:
@@ -15,10 +15,46 @@ tests:
               Host: localhost
               User-Agent: SOGo rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: text/calendar
+              Content-Type: text/calendar;charset=utf-8
             port: 80
-            method: GET
-            uri: /SOGo/dav/username/Calendar/stuff/reminders.ics
+            method: PUT
+            uri: /SOGo/dav/user@example.com/Calendar/personal/7490c58f-897e-4013-888f-bba5b35e62f2.ics
+            data: |-
+              BEGIN:VCALENDAR
+              VERSION:2.0
+              PRODID:DAVx5/4.4.8-ose ical4j/3.2.19 (org.fossify.calendar)
+              BEGIN:VEVENT
+              DTSTAMP:20250319T043635Z
+              UID:7490c58f-897e-4013-888f-bba5b35e62f2
+              SUMMARY:Test
+              DTSTART;TZID=Australia/Sydney:20250319T160000
+              DTEND;TZID=Australia/Sydney:20250319T160000
+              STATUS:CONFIRMED
+              BEGIN:VALARM
+              TRIGGER:-PT1H
+              ACTION:DISPLAY
+              DESCRIPTION:Test
+              END:VALARM
+              END:VEVENT
+              BEGIN:VTIMEZONE
+              TZID:Australia/Sydney
+              BEGIN:STANDARD
+              TZNAME:AEST
+              TZOFFSETFROM:+1100
+              TZOFFSETTO:+1000
+              DTSTART:20080406T030000
+              RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU
+              END:STANDARD
+              BEGIN:DAYLIGHT
+              TZNAME:AEDT
+              TZOFFSETFROM:+1000
+              TZOFFSETTO:+1100
+              DTSTART:20081005T020000
+              RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU
+              END:DAYLIGHT
+              END:VTIMEZONE
+              END:VCALENDAR
             version: HTTP/1.1
           output:
-            no_log_contains: id "920420"
+            no_log_contains: |-
+              id "911100"|id "920420"


### PR DESCRIPTION
This PR includes two fixes:
1. Allow the MKCALENDAR request method when creating a new calendar group
2. Fixes false positives on Apache when syncing contacts

new tests have been added for rules relating to CalDAV and CardDAV